### PR TITLE
Revision #2

### DIFF
--- a/mija/src/components/Home/Home.js
+++ b/mija/src/components/Home/Home.js
@@ -23,6 +23,8 @@ const useStyles = makeStyles(theme => ({
         width: '100%',
     },
     textDiv: {
+        display: 'flex',
+        alignItems: 'center',
         position: 'absolute',
         height: '100%',
         right: 0,

--- a/mija/src/components/Home/Home.js
+++ b/mija/src/components/Home/Home.js
@@ -17,7 +17,9 @@ const useStyles = makeStyles(theme => ({
     },
     imageDiv: {
         position: 'relative',
-        width: '100%',
+        // width: '100%',
+        display: 'flex',
+        flexDirection:'column',
     },
     imageAloe: {
         width: '100%',
@@ -25,13 +27,13 @@ const useStyles = makeStyles(theme => ({
     textDiv: {
         display: 'flex',
         alignItems: 'center',
-        position: 'absolute',
         height: '100%',
         right: 0,
         marginLeft: 'auto',
         backgroundColor: 'rgba(255, 255, 255, .5)',
         overflow: 'auto',
         [theme.breakpoints.up('sm')]: {
+            position: 'absolute',
             width: '50%',
         },
     },


### PR DESCRIPTION
## Chrome:

**Home Page:**

1. The image size is fixed but now the text is not aligned vertically.
    - It was never vertically aligned, you had margin in '%' which might work in some screen sizes but not all. It's properly aligned now.
2. The blue bar in the center "biodegradable" has a think white space above it.
    - My bad, fixed it.
3. Ingredients Page: The text and images are misaligned vertically and there is a very large empty white space at the bottom. Therefore, its NOT responsive to Chrome.
    - All text looks aligned to me.
    - The large empty space is coming from your footer (one with social icons), and it's there on every page. If you want it's size reduced for mobile, say so.
4. The About Page also has a very large white space beneath it.
    - Every page has it. When making websites responsive we fix the width, so everything fits without side scroll. Usually no changes is done in vertical stuff, but you want it changed let me know.

## Safari:

1. When I resize the window on my desktop, it turns into the mobile version.
    - Umm, yeah obviously, if you resize the window and to decrease the width it will switch to mobile version. That's how websites figure out if it's mobile or desktop, by browser's width.

## Firefox:

1. Same spacing issues as Chrome and Safari.

2. When resize window on desktop, immediately changes to mobile version which has some formatting errors.
    - Smaller width browser window will switch to mobile version.
    - Be specific, what formatting errors.

## iPhone:

**Home Page:**
1. the main text scrolls over the image which interferes with the page scrolling.
    - Well given the Aspect Ratio of image, it can't have similar style as desktop version as text will not fit, so it was scrollable. But yeah, it interferes with actual page scroll, so I have removed it. Image and text show separately now.

## iPad:

**Home Page:**
1. minor spacing issues vertically and horizontally
    - Again, be specific.
